### PR TITLE
Correct warnings should not have newlines

### DIFF
--- a/latches/build.rs
+++ b/latches/build.rs
@@ -7,35 +7,37 @@ fn main() {
 
     if !output.status.success() {
         return println!(
-            "cargo:warning=latches: {}",
+            "cargo:warning=latches: Failed `rustc -vV`: {}",
             String::from_utf8_lossy(&output.stderr)
         );
     }
 
     let output = String::from_utf8_lossy(&output.stdout);
+
     for line in output.lines() {
         if let Some(version) = line.strip_prefix("release: ") {
-            if let Some((ver, _)) = version.rsplit_once('.') {
-                if let Some(v) = into_tuple(ver) {
-                    if v < (1, 63) {
-                        println!("cargo:rustc-cfg=latches_no_const_sync");
-                    }
-                    return;
+            if let Some(v) = version_tuple(version) {
+                if v < (1, 63) {
+                    println!("cargo:rustc-cfg=latches_no_const_sync");
                 }
+                return;
+            } else {
+                println!("cargo:warning=latches: Unexpected version: {line}");
             }
         }
     }
-    println!(
-        "cargo:warning=latches: Unexpected output from `rustc -vV`:\n{}",
-        output
-    )
+
+    println!("cargo:warning=latches: No version line in `rustc -vV` output");
 }
 
-fn into_tuple(version: &str) -> Option<(u16, u16)> {
-    if let Some((major, minor)) = version.split_once('.') {
-        if let (Ok(maj), Ok(min)) = (major.parse(), minor.parse()) {
-            return Some((maj, min));
+fn version_tuple(version: &str) -> Option<(u16, u16)> {
+    let mut v = version.splitn(3, '.');
+
+    if let (Some(f), Some(s)) = (v.next(), v.next()) {
+        if let (Ok(major), Ok(minor)) = (f.parse(), s.parse()) {
+            return Some((major, minor));
         }
     }
+
     None
 }


### PR DESCRIPTION
Cargo warning messages cannot have line breaks, otherwise subsequent lines will not be visible.