### PR TITLE
Remove unnecessary gated imports

### DIFF
--- a/latches/src/futex/mod.rs
+++ b/latches/src/futex/mod.rs
@@ -1,13 +1,3 @@
-#[cfg(feature = "std")]
-use std::{
-    fmt, hint,
-    sync::atomic::{
-        AtomicU32,
-        Ordering::{Acquire, Relaxed, Release},
-    },
-};
-
-#[cfg(not(feature = "std"))]
 use core::{
     fmt, hint,
     sync::atomic::{

--- a/latches/src/sync/mod.rs
+++ b/latches/src/sync/mod.rs
@@ -1,14 +1,3 @@
-#[cfg(feature = "std")]
-use std::{
-    fmt, hint,
-    sync::atomic::{
-        AtomicUsize,
-        Ordering::{Acquire, Relaxed, Release},
-    },
-    time::{Duration, Instant},
-};
-
-#[cfg(not(feature = "std"))]
 use core::{
     fmt, hint,
     sync::atomic::{
@@ -16,6 +5,9 @@ use core::{
         Ordering::{Acquire, Relaxed, Release},
     },
 };
+
+#[cfg(feature = "std")]
+use std::time::{Duration, Instant};
 
 #[cfg(all(not(feature = "std"), not(feature = "atomic-wait")))]
 compile_error!("`sync` requires `std` or `atomic-wait` feature for Condvar");

--- a/latches/src/task/mod.rs
+++ b/latches/src/task/mod.rs
@@ -1,17 +1,3 @@
-#[cfg(feature = "std")]
-use std::{
-    fmt,
-    future::Future,
-    hint,
-    pin::Pin,
-    sync::atomic::{
-        AtomicUsize,
-        Ordering::{Acquire, Relaxed, Release},
-    },
-    task::{Context, Poll},
-};
-
-#[cfg(not(feature = "std"))]
 use core::{
     fmt,
     future::Future,


### PR DESCRIPTION
Some of the gated std imports are just re-exported from core/alloc, so we could just always use the core deps, no need to gate them.